### PR TITLE
[Hotfix] Hide search bar from guests

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -14,14 +14,13 @@
       </span>
     </div>
     <div id="navbarMenu" class="navbar-menu">
-      <div class="navbar-end">
-        <span class="navbar-item">
-          <%= render "layouts/searchbar" %>
-        </span>
-      </div>
-      <div class="navbar-end">
-        <% if user_signed_in? %>
-
+      <% if user_signed_in? %>
+        <div class="navbar-end">
+          <span class="navbar-item">
+            <%= render "layouts/searchbar" %>
+          </span>
+        </div>
+        <div class="navbar-end">
           <span class="navbar-item">
             <%= link_to(new_recipe_path) do %>
               <span class="icon">
@@ -73,8 +72,9 @@
           <span class="navbar-item">
             <%= button_to "Log Out", destroy_user_session_path, method: :delete, class: 'button is-dark' %>
           </span>
-
-        <% else %>
+        </div>
+      <% else %>
+        <div class="navbar-end">
 
           <span class="navbar-item">
             <%= link_to "Sign Up", new_user_registration_path, class:  "button is-dark" %>
@@ -89,9 +89,10 @@
               </span>
             <% end %>
           </span>
-        <% end %>
+        </div>
+      <% end %>
 
-      </div>
+        
     </div>
   </nav>
 </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -91,8 +91,6 @@
           </span>
         </div>
       <% end %>
-
-        
     </div>
   </nav>
 </div>


### PR DESCRIPTION
## Description
The search bar needs an active user session, so leaving it to be used by guests would cause crashes.﻿
